### PR TITLE
Releasing v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.0]
+
+### Added
+- [`xkafka`](./xkafka) Added `xkafka` package with `Producer` and `Consumer` implementations that support middleware & HTTP-like handlers.
+
 ## [0.1.1]
 
 ### Changed
@@ -21,7 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - [`generic`](./generic) package added
 - [`xproto`](./xproto) package added
 
-[Unreleased]: https://github.com/gojekfarm/xtools/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/gojekfarm/xtools/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/gojekfarm/xtools/releases/tag/v0.2.0
 [0.1.1]: https://github.com/gojekfarm/xtools/releases/tag/v0.1.1
 [0.1.0]: https://github.com/gojekfarm/xtools/releases/tag/v0.1.0
 

--- a/examples/xkafka/go.mod
+++ b/examples/xkafka/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/gojekfarm/xrun v0.3.0
-	github.com/gojekfarm/xtools/xkafka v0.0.0-00010101000000-000000000000
+	github.com/gojekfarm/xtools/xkafka v0.2.0
 	github.com/rs/xid v1.4.0
 	github.com/rs/zerolog v1.29.0
 )

--- a/version.go
+++ b/version.go
@@ -2,6 +2,6 @@ package xtools
 
 // Version can be used to get the current xtools library version
 func Version() string {
-	return "0.1.1"
+	return "0.2.0"
 	// This string is updated by the pre_release.sh script during release
 }

--- a/xkafka/middleware/go.mod
+++ b/xkafka/middleware/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace github.com/gojekfarm/xtools/xkafka => ../
 
 require (
-	github.com/gojekfarm/xtools/xkafka v0.0.0-00010101000000-000000000000
+	github.com/gojekfarm/xtools/xkafka v0.2.0
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
### Added
- [`xkafka`](./xkafka) Added `xkafka` package with `Producer` and `Consumer` implementations that support middleware & HTTP-like handlers.