### PR TITLE
feat: include more context in errors

### DIFF
--- a/xload/async_test.go
+++ b/xload/async_test.go
@@ -116,7 +116,7 @@ func Test_loadAndSetWithOriginal(t *testing.T) {
 	}
 
 	t.Run("successful load and set", func(t *testing.T) {
-		meta := &field{name: "testName", required: true}
+		meta := &field{key: "testName", required: true}
 
 		obj := &Args{
 			Nest: &struct {
@@ -137,7 +137,7 @@ func Test_loadAndSetWithOriginal(t *testing.T) {
 	})
 
 	t.Run("loader returns error", func(t *testing.T) {
-		meta := &field{name: "testName", required: true}
+		meta := &field{key: "testName", required: true}
 		original := reflect.ValueOf(new(string))
 		fVal := reflect.ValueOf(new(string))
 
@@ -148,8 +148,8 @@ func Test_loadAndSetWithOriginal(t *testing.T) {
 		assert.Equal(t, "load error", err.Error())
 	})
 
-	t.Run("field is required but loader val is empty", func(t *testing.T) {
-		meta := &field{name: "testName", required: true}
+	t.Run("key is required but loader val is empty", func(t *testing.T) {
+		meta := &field{key: "testName", required: true}
 		original := reflect.ValueOf(new(string))
 		fVal := reflect.ValueOf(new(string))
 
@@ -157,6 +157,9 @@ func Test_loadAndSetWithOriginal(t *testing.T) {
 			return "", nil
 		}), meta)(context.Background(), original, fVal, true)
 		assert.NotNil(t, err)
-		assert.Equal(t, ErrRequired, err)
+
+		wantErr := &ErrRequired{}
+		assert.ErrorAs(t, err, &wantErr)
+		assert.Equal(t, "testName", wantErr.key)
 	})
 }

--- a/xload/errors.go
+++ b/xload/errors.go
@@ -1,0 +1,60 @@
+package xload
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ErrRequired is returned when a required key is missing.
+type ErrRequired struct{ key string }
+
+func (e *ErrRequired) Error() string { return "required key missing: " + e.key }
+
+// ErrUnknownTagOption is returned when an unknown tag option is used.
+type ErrUnknownTagOption struct {
+	key string
+	opt string
+}
+
+func (e *ErrUnknownTagOption) Error() string {
+	if e.key == "" {
+		return fmt.Sprintf("unknown tag option: %s", e.opt)
+	}
+
+	return fmt.Sprintf("`%s` key has unknown tag option: %s", e.key, e.opt)
+}
+
+// ErrUnknownFieldType is returned when the key type is not supported.
+type ErrUnknownFieldType struct {
+	field string
+	kind  reflect.Kind
+	key   string
+}
+
+func (e *ErrUnknownFieldType) Error() string {
+	return fmt.Sprintf("`%s: %s` key=%s has an invalid value", e.field, e.kind, e.key)
+}
+
+// ErrInvalidMapValue is returned when the map value is invalid.
+type ErrInvalidMapValue struct{ key string }
+
+func (e *ErrInvalidMapValue) Error() string {
+	return fmt.Sprintf("`%s` key has an invalid map value", e.key)
+}
+
+// ErrInvalidPrefix is returned when the prefix option is used on a non-struct key.
+type ErrInvalidPrefix struct {
+	field string
+	kind  reflect.Kind
+}
+
+func (e *ErrInvalidPrefix) Error() string {
+	return fmt.Sprintf("prefix is only valid on struct types, found `%s: %s`", e.field, e.kind)
+}
+
+// ErrInvalidPrefixAndKey is returned when the prefix option is used with a key.
+type ErrInvalidPrefixAndKey struct{ key string }
+
+func (e *ErrInvalidPrefixAndKey) Error() string {
+	return fmt.Sprintf("`%s` key has both prefix and key", e.key)
+}

--- a/xload/errors.go
+++ b/xload/errors.go
@@ -8,7 +8,7 @@ import (
 // ErrRequired is returned when a required key is missing.
 type ErrRequired struct{ key string }
 
-func (e *ErrRequired) Error() string { return "required key missing: " + e.key }
+func (e ErrRequired) Error() string { return "required key missing: " + e.key }
 
 // ErrUnknownTagOption is returned when an unknown tag option is used.
 type ErrUnknownTagOption struct {
@@ -16,7 +16,7 @@ type ErrUnknownTagOption struct {
 	opt string
 }
 
-func (e *ErrUnknownTagOption) Error() string {
+func (e ErrUnknownTagOption) Error() string {
 	if e.key == "" {
 		return fmt.Sprintf("unknown tag option: %s", e.opt)
 	}
@@ -31,14 +31,14 @@ type ErrUnknownFieldType struct {
 	key   string
 }
 
-func (e *ErrUnknownFieldType) Error() string {
+func (e ErrUnknownFieldType) Error() string {
 	return fmt.Sprintf("`%s: %s` key=%s has an invalid value", e.field, e.kind, e.key)
 }
 
 // ErrInvalidMapValue is returned when the map value is invalid.
 type ErrInvalidMapValue struct{ key string }
 
-func (e *ErrInvalidMapValue) Error() string {
+func (e ErrInvalidMapValue) Error() string {
 	return fmt.Sprintf("`%s` key has an invalid map value", e.key)
 }
 
@@ -48,7 +48,7 @@ type ErrInvalidPrefix struct {
 	kind  reflect.Kind
 }
 
-func (e *ErrInvalidPrefix) Error() string {
+func (e ErrInvalidPrefix) Error() string {
 	return fmt.Sprintf("prefix is only valid on struct types, found `%s: %s`", e.field, e.kind)
 }
 
@@ -58,6 +58,6 @@ type ErrInvalidPrefixAndKey struct {
 	key   string
 }
 
-func (e *ErrInvalidPrefixAndKey) Error() string {
+func (e ErrInvalidPrefixAndKey) Error() string {
 	return fmt.Sprintf("`%s` key=%s has both prefix and key", e.field, e.key)
 }

--- a/xload/errors.go
+++ b/xload/errors.go
@@ -53,8 +53,11 @@ func (e *ErrInvalidPrefix) Error() string {
 }
 
 // ErrInvalidPrefixAndKey is returned when the prefix option is used with a key.
-type ErrInvalidPrefixAndKey struct{ key string }
+type ErrInvalidPrefixAndKey struct {
+	field string
+	key   string
+}
 
 func (e *ErrInvalidPrefixAndKey) Error() string {
-	return fmt.Sprintf("`%s` key has both prefix and key", e.key)
+	return fmt.Sprintf("`%s` key=%s has both prefix and key", e.field, e.key)
 }

--- a/xload/errors_test.go
+++ b/xload/errors_test.go
@@ -1,8 +1,9 @@
 package xload
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestErrUnknownTagOption_Error(t *testing.T) {

--- a/xload/errors_test.go
+++ b/xload/errors_test.go
@@ -1,0 +1,37 @@
+package xload
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestErrUnknownTagOption_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		opt  string
+		want string
+	}{
+		{
+			name: "key and opt",
+			key:  "key",
+			opt:  "opt",
+			want: "`key` key has unknown tag option: opt",
+		},
+		{
+			name: "opt only",
+			opt:  "opt",
+			want: "unknown tag option: opt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &ErrUnknownTagOption{
+				key: tt.key,
+				opt: tt.opt,
+			}
+			assert.Equalf(t, tt.want, e.Error(), "Error()")
+		})
+	}
+}

--- a/xload/load.go
+++ b/xload/load.go
@@ -17,20 +17,8 @@ var (
 	ErrNotPointer = errors.New("xload: config must be a pointer")
 	// ErrNotStruct is returned when the given config is not a struct.
 	ErrNotStruct = errors.New("xload: config must be a struct")
-	// ErrUnknownTagOption is returned when an unknown tag option is used.
-	ErrUnknownTagOption = errors.New("xload: unknown tag option")
-	// ErrRequired is returned when a required field is missing.
-	ErrRequired = errors.New("xload: missing required value")
-	// ErrUnknownFieldType is returned when the field type is not supported.
-	ErrUnknownFieldType = errors.New("xload: unknown field type")
-	// ErrInvalidMapValue is returned when the map value is invalid.
-	ErrInvalidMapValue = errors.New("xload: invalid map value")
 	// ErrMissingKey is returned when the key is missing from the tag.
-	ErrMissingKey = errors.New("xload: missing key")
-	// ErrInvalidPrefix is returned when the prefix option is used on a non-struct field.
-	ErrInvalidPrefix = errors.New("xload: prefix is only valid on struct types")
-	// ErrInvalidPrefixAndKey is returned when the prefix option is used with a key.
-	ErrInvalidPrefixAndKey = errors.New("xload: prefix cannot be used when field name is set")
+	ErrMissingKey = errors.New("xload: missing key on required field")
 )
 
 const (
@@ -86,7 +74,7 @@ func process(ctx context.Context, obj any, tagKey string, loader Loader) error {
 			continue
 		}
 
-		meta, err := parseField(tag)
+		meta, err := parseField(fTyp.Name, tag)
 		if err != nil {
 			return err
 		}
@@ -127,14 +115,14 @@ func process(ctx context.Context, obj any, tagKey string, loader Loader) error {
 
 			// if the struct has a key, load it
 			// and set the value to the struct
-			if meta.name != "" {
-				val, err := loader.Load(ctx, meta.name)
+			if meta.key != "" {
+				val, err := loader.Load(ctx, meta.key)
 				if err != nil {
 					return err
 				}
 
 				if val == "" && meta.required {
-					return ErrRequired
+					return &ErrRequired{key: meta.key}
 				}
 
 				if ok, err := decode(fVal, val); ok {
@@ -164,17 +152,17 @@ func process(ctx context.Context, obj any, tagKey string, loader Loader) error {
 		}
 
 		if meta.prefix != "" {
-			return ErrInvalidPrefix
+			return &ErrInvalidPrefix{field: fTyp.Name, kind: fVal.Kind()}
 		}
 
 		// lookup value
-		val, err := loader.Load(ctx, meta.name)
+		val, err := loader.Load(ctx, meta.key)
 		if err != nil {
 			return err
 		}
 
 		if val == "" && meta.required {
-			return ErrRequired
+			return &ErrRequired{key: meta.key}
 		}
 
 		// set value
@@ -189,18 +177,20 @@ func process(ctx context.Context, obj any, tagKey string, loader Loader) error {
 
 type field struct {
 	name      string
+	key       string
 	prefix    string
 	required  bool
 	delimiter string
 	separator string
 }
 
-func parseField(tag string) (*field, error) {
+func parseField(name, tag string) (*field, error) {
 	parts := strings.Split(tag, ",")
 	key, tagOpts := strings.TrimSpace(parts[0]), parts[1:]
 
 	f := &field{
-		name:      key,
+		name:      name,
+		key:       key,
 		delimiter: defaultDelimiter,
 		separator: defaultSeparator,
 	}
@@ -219,14 +209,14 @@ func parseField(tag string) (*field, error) {
 			f.prefix = strings.TrimPrefix(opt, optPrefix)
 
 			if key != "" && f.prefix != "" {
-				return nil, ErrInvalidPrefixAndKey
+				return nil, &ErrInvalidPrefixAndKey{key: key}
 			}
 		case strings.HasPrefix(opt, optDelimiter):
 			f.delimiter = strings.TrimPrefix(opt, optDelimiter)
 		case strings.HasPrefix(opt, optSeparator):
 			f.separator = strings.TrimPrefix(opt, optSeparator)
 		default:
-			return nil, ErrUnknownTagOption
+			return nil, &ErrUnknownTagOption{key: key, opt: opt}
 		}
 	}
 
@@ -318,7 +308,7 @@ func setVal(field reflect.Value, val string, meta *field) error {
 		for _, v := range vals {
 			kv := strings.Split(v, meta.separator)
 			if len(kv) != 2 {
-				return ErrInvalidMapValue
+				return &ErrInvalidMapValue{key: meta.key}
 			}
 
 			k, v := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
@@ -365,7 +355,7 @@ func setVal(field reflect.Value, val string, meta *field) error {
 		field.Set(slice)
 
 	default:
-		return ErrUnknownFieldType
+		return &ErrUnknownFieldType{field: meta.name, key: meta.key, kind: kd}
 	}
 
 	return nil

--- a/xload/load.go
+++ b/xload/load.go
@@ -209,7 +209,7 @@ func parseField(name, tag string) (*field, error) {
 			f.prefix = strings.TrimPrefix(opt, optPrefix)
 
 			if key != "" && f.prefix != "" {
-				return nil, &ErrInvalidPrefixAndKey{key: key}
+				return nil, &ErrInvalidPrefixAndKey{field: name, key: key}
 			}
 		case strings.HasPrefix(opt, optDelimiter):
 			f.delimiter = strings.TrimPrefix(opt, optDelimiter)

--- a/xload/load_struct_test.go
+++ b/xload/load_struct_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -73,6 +74,8 @@ func (p *Plots) Decode(s string) error {
 
 func TestLoad_Structs(t *testing.T) {
 	t.Parallel()
+
+	strKind := reflect.TypeOf("").Kind()
 
 	testcases := []testcase{
 		{
@@ -168,19 +171,19 @@ func TestLoad_Structs(t *testing.T) {
 			},
 		},
 		{
-			name: "non-struct field with prefix",
+			name: "non-struct key with prefix",
 			input: &struct {
 				Name string `env:",prefix=CLUSTER"`
 			}{},
-			err:    ErrInvalidPrefix,
+			err:    &ErrInvalidPrefix{field: "Name", kind: strKind},
 			loader: MapLoader{},
 		},
 		{
-			name: "struct field with name and prefix",
+			name: "struct key with key and prefix",
 			input: &struct {
 				Address Address `env:"ADDRESS,prefix=CLUSTER"`
 			}{},
-			err:    ErrInvalidPrefixAndKey,
+			err:    &ErrInvalidPrefixAndKey{key: "ADDRESS"},
 			loader: MapLoader{},
 		},
 	}
@@ -318,7 +321,7 @@ func TestLoad_JSON(t *testing.T) {
 			input: &struct {
 				Plot Plot `env:"PLOT,required"`
 			}{},
-			err:    ErrRequired,
+			err:    &ErrRequired{key: "PLOT"},
 			loader: MapLoader{},
 		},
 	}

--- a/xload/load_struct_test.go
+++ b/xload/load_struct_test.go
@@ -179,11 +179,11 @@ func TestLoad_Structs(t *testing.T) {
 			loader: MapLoader{},
 		},
 		{
-			name: "struct key with key and prefix",
+			name: "struct with key and prefix",
 			input: &struct {
 				Address Address `env:"ADDRESS,prefix=CLUSTER"`
 			}{},
-			err:    &ErrInvalidPrefixAndKey{key: "ADDRESS"},
+			err:    &ErrInvalidPrefixAndKey{field: "Address", key: "ADDRESS"},
 			loader: MapLoader{},
 		},
 	}


### PR DESCRIPTION
Current errors do not provide much info into where to look for malformed values. This change aims to provide more context around errors.