### PR TITLE
Validate Consumer & Producer configs

### DIFF
--- a/examples/xkafka/async.go
+++ b/examples/xkafka/async.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"time"
 
+	"log/slog"
+
 	"github.com/rs/xid"
 	"github.com/urfave/cli/v2"
-	"log/slog"
 
 	"github.com/gojekfarm/xrun"
 	"github.com/gojekfarm/xtools/xkafka"
@@ -22,7 +23,7 @@ func runAsync(c *cli.Context) error {
 
 	s.generated = generateMessages(topic, 10)
 
-	opts := []xkafka.Option{
+	opts := []xkafka.ConsumerOption{
 		xkafka.Brokers(brokers),
 		xkafka.Topics{topic},
 		xkafka.ConfigMap{

--- a/examples/xkafka/async.go
+++ b/examples/xkafka/async.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"time"
 
-	"log/slog"
-
 	"github.com/rs/xid"
 	"github.com/urfave/cli/v2"
+	"log/slog"
 
 	"github.com/gojekfarm/xrun"
 	"github.com/gojekfarm/xtools/xkafka"
@@ -30,6 +29,10 @@ func runAsync(c *cli.Context) error {
 			"auto.offset.reset": "earliest",
 		},
 		xkafka.Concurrency(2),
+		xkafka.ErrorHandler(func(err error) error {
+			slog.Error(err.Error())
+			return nil
+		}),
 	}
 
 	// start consumers first

--- a/examples/xkafka/sequential.go
+++ b/examples/xkafka/sequential.go
@@ -6,10 +6,9 @@ import (
 	"math/rand"
 	"time"
 
-	"log/slog"
-
 	"github.com/rs/xid"
 	"github.com/urfave/cli/v2"
+	"log/slog"
 
 	"github.com/gojekfarm/xrun"
 	"github.com/gojekfarm/xtools/xkafka"
@@ -36,6 +35,10 @@ func runSequential(c *cli.Context) error {
 		xkafka.ConfigMap{
 			"auto.offset.reset": "earliest",
 		},
+		xkafka.ErrorHandler(func(err error) error {
+			slog.Error(err.Error())
+			return nil
+		}),
 	}
 
 	// start consumers first

--- a/examples/xkafka/sequential.go
+++ b/examples/xkafka/sequential.go
@@ -6,9 +6,10 @@ import (
 	"math/rand"
 	"time"
 
+	"log/slog"
+
 	"github.com/rs/xid"
 	"github.com/urfave/cli/v2"
-	"log/slog"
 
 	"github.com/gojekfarm/xrun"
 	"github.com/gojekfarm/xtools/xkafka"
@@ -29,7 +30,7 @@ func runSequential(c *cli.Context) error {
 
 	s.generated = generateMessages(topic, 10)
 
-	opts := []xkafka.Option{
+	opts := []xkafka.ConsumerOption{
 		xkafka.Brokers(brokers),
 		xkafka.Topics{topic},
 		xkafka.ConfigMap{

--- a/xkafka/confluent.go
+++ b/xkafka/confluent.go
@@ -18,7 +18,7 @@ type consumerClient interface {
 
 type consumerFunc func(cfg *kafka.ConfigMap) (consumerClient, error)
 
-func (cf consumerFunc) apply(o *options) { o.consumerFn = cf }
+func (cf consumerFunc) setConsumerConfig(o *consumerConfig) { o.consumerFn = cf }
 
 func defaultConsumerFunc(cfg *kafka.ConfigMap) (consumerClient, error) {
 	return kafka.NewConsumer(cfg)
@@ -34,7 +34,7 @@ type producerClient interface {
 
 type producerFunc func(cfg *kafka.ConfigMap) (producerClient, error)
 
-func (pf producerFunc) apply(o *options) { o.producerFn = pf }
+func (pf producerFunc) setProducerConfig(o *producerConfig) { o.producerFn = pf }
 
 func defaultProducerFunc(cfg *kafka.ConfigMap) (producerClient, error) {
 	return kafka.NewProducer(cfg)

--- a/xkafka/consumer_options.go
+++ b/xkafka/consumer_options.go
@@ -1,0 +1,82 @@
+package xkafka
+
+import (
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+// ConsumerOption is an interface for consumer options.
+type ConsumerOption interface{ setConsumerConfig(*consumerConfig) }
+
+type consumerConfig struct {
+	brokers         []string
+	configMap       kafka.ConfigMap
+	errorHandler    ErrorHandler
+	shutdownTimeout time.Duration
+	consumerFn      consumerFunc
+	topics          []string
+	metadataTimeout time.Duration
+	pollTimeout     time.Duration
+	concurrency     int
+	manualCommit    bool
+}
+
+func newConsumerConfig(opts ...ConsumerOption) (*consumerConfig, error) {
+	cfg := &consumerConfig{
+		consumerFn:      defaultConsumerFunc,
+		topics:          []string{},
+		brokers:         []string{},
+		configMap:       kafka.ConfigMap{},
+		errorHandler:    NoopErrorHandler,
+		metadataTimeout: 10 * time.Second,
+		pollTimeout:     10 * time.Second,
+		shutdownTimeout: 1 * time.Second,
+		concurrency:     1,
+	}
+
+	for _, opt := range opts {
+		opt.setConsumerConfig(cfg)
+	}
+
+	return cfg, nil
+}
+
+// Topics sets the kafka topics to consume.
+type Topics []string
+
+func (t Topics) setConsumerConfig(o *consumerConfig) { o.topics = t }
+
+// PollTimeout defines the timeout for the consumer read timeout.
+type PollTimeout time.Duration
+
+func (pt PollTimeout) setConsumerConfig(o *consumerConfig) {
+	o.pollTimeout = time.Duration(pt)
+}
+
+// MetadataTimeout defines the timeout for the consumer metadata request.
+type MetadataTimeout time.Duration
+
+func (mt MetadataTimeout) setConsumerConfig(o *consumerConfig) {
+	o.metadataTimeout = time.Duration(mt)
+}
+
+// Concurrency defines the concurrency of the consumer.
+type Concurrency int
+
+func (c Concurrency) setConsumerConfig(o *consumerConfig) {
+	o.concurrency = int(c)
+}
+
+// ManualCommit disables the auto commit and calls the `Commit` after every
+// message is marked as `Success` or `Skip` by the handler.
+//
+// Works only for xkafka.Consumer.
+//
+// WARNING: Using this option will increase the message processing time,
+// because of the synchronous `Commit` for every message.
+type ManualCommit bool
+
+func (mc ManualCommit) setConsumerConfig(o *consumerConfig) {
+	o.manualCommit = bool(mc)
+}

--- a/xkafka/consumer_test.go
+++ b/xkafka/consumer_test.go
@@ -16,10 +16,12 @@ import (
 var (
 	testTopics  = Topics{"test-topic"}
 	testBrokers = Brokers{"localhost:9092"}
+	errHandler  = ErrorHandler(func(err error) error { return err })
 	testTimeout = time.Second
 	defaultOpts = []ConsumerOption{
 		testTopics,
 		testBrokers,
+		errHandler,
 		PollTimeout(testTimeout),
 	}
 )
@@ -67,33 +69,55 @@ func TestNewConsumer(t *testing.T) {
 	assert.EqualValues(t, expectedConfig, consumer.config.configMap)
 }
 
-func TestNewConsumerError(t *testing.T) {
+func TestNewConsumerErrors(t *testing.T) {
 	t.Parallel()
 
-	expectError := errors.New("error in consumer")
-
-	fn := func(configMap *kafka.ConfigMap) (consumerClient, error) {
-		return nil, expectError
+	testcases := []struct {
+		name    string
+		options []ConsumerOption
+		expect  error
+	}{
+		{
+			name:    "missing brokers",
+			options: []ConsumerOption{testTopics, errHandler},
+			expect:  ErrRequiredOption,
+		},
+		{
+			name:    "missing topics",
+			options: []ConsumerOption{testBrokers, errHandler},
+			expect:  ErrRequiredOption,
+		},
+		{
+			name:    "missing error handler",
+			options: []ConsumerOption{testBrokers, testTopics},
+			expect:  ErrRequiredOption,
+		},
+		{
+			name: "consumer error",
+			options: []ConsumerOption{
+				testTopics, testBrokers, errHandler,
+				consumerFunc(func(configMap *kafka.ConfigMap) (consumerClient, error) {
+					return nil, assert.AnError
+				}),
+			},
+			expect: assert.AnError,
+		},
 	}
 
-	_, err := NewConsumer(
-		"test-consumer",
-		noopHandler(),
-		consumerFunc(fn),
-	)
-	assert.Error(t, err)
-	assert.Equal(t, expectError, err)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewConsumer("test-consumer", noopHandler(), tc.options...)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, tc.expect)
+		})
+	}
 }
 
 func TestConsumerLifecycle(t *testing.T) {
 	t.Parallel()
 
 	t.Run("StartSubscribeError", func(t *testing.T) {
-		consumer, mockKafka := newTestConsumer(t,
-			testTopics,
-			testBrokers,
-			PollTimeout(testTimeout),
-		)
+		consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 		expectError := errors.New("error in subscribe")
 
@@ -105,11 +129,7 @@ func TestConsumerLifecycle(t *testing.T) {
 	})
 
 	t.Run("StartSuccessCloseError", func(t *testing.T) {
-		consumer, mockKafka := newTestConsumer(t,
-			testTopics,
-			testBrokers,
-			PollTimeout(testTimeout),
-		)
+		consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 		mockKafka.On("SubscribeTopics", []string(testTopics), mock.Anything).Return(nil)
 		mockKafka.On("Unsubscribe").Return(nil)
@@ -125,11 +145,7 @@ func TestConsumerLifecycle(t *testing.T) {
 	})
 
 	t.Run("StartCloseSuccess", func(t *testing.T) {
-		consumer, mockKafka := newTestConsumer(t,
-			testTopics,
-			testBrokers,
-			PollTimeout(testTimeout),
-		)
+		consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 		mockKafka.On("SubscribeTopics", []string(testTopics), mock.Anything).Return(nil)
 		mockKafka.On("Unsubscribe").Return(nil)
@@ -148,11 +164,7 @@ func TestConsumerLifecycle(t *testing.T) {
 func TestConsumerGetMetadata(t *testing.T) {
 	t.Parallel()
 
-	consumer, mockKafka := newTestConsumer(t,
-		testTopics,
-		testBrokers,
-		PollTimeout(testTimeout),
-	)
+	consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 	mockKafka.On("GetMetadata", mock.Anything, false, 10000).Return(&kafka.Metadata{}, nil)
 	mockKafka.On("Close").Return(nil)
@@ -169,11 +181,7 @@ func TestConsumerGetMetadata(t *testing.T) {
 func TestConsumerSubscribeError(t *testing.T) {
 	t.Parallel()
 
-	consumer, mockKafka := newTestConsumer(t,
-		testTopics,
-		testBrokers,
-		PollTimeout(testTimeout),
-	)
+	consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 	ctx := context.Background()
 	expectError := errors.New("error")
@@ -189,11 +197,7 @@ func TestConsumerSubscribeError(t *testing.T) {
 func TestConsumerUnsubscribeError(t *testing.T) {
 	t.Parallel()
 
-	consumer, mockKafka := newTestConsumer(t,
-		testTopics,
-		testBrokers,
-		PollTimeout(testTimeout),
-	)
+	consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 	km := newFakeKafkaMessage()
 	ctx := context.Background()
@@ -220,11 +224,7 @@ func TestConsumerUnsubscribeError(t *testing.T) {
 func TestConsumerHandleMessage(t *testing.T) {
 	t.Parallel()
 
-	consumer, mockKafka := newTestConsumer(t,
-		testTopics,
-		testBrokers,
-		PollTimeout(testTimeout),
-	)
+	consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 	km := newFakeKafkaMessage()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -458,11 +458,7 @@ func TestConsumerKafkaError(t *testing.T) {
 func TestConsumerMiddlewareExecutionOrder(t *testing.T) {
 	t.Parallel()
 
-	consumer, mockKafka := newTestConsumer(t,
-		testTopics,
-		testBrokers,
-		PollTimeout(testTimeout),
-	)
+	consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 
 	km := newFakeKafkaMessage()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -508,11 +504,7 @@ func TestConsumerManualCommit(t *testing.T) {
 	t.Parallel()
 
 	consumer, mockKafka := newTestConsumer(t,
-		testTopics,
-		testBrokers,
-		PollTimeout(testTimeout),
-		ManualCommit(true),
-	)
+		append(defaultOpts, ManualCommit(true))...)
 
 	km := newFakeKafkaMessage()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -544,11 +536,7 @@ func TestConsumerAsync(t *testing.T) {
 	t.Parallel()
 
 	consumer, mockKafka := newTestConsumer(t,
-		testTopics,
-		testBrokers,
-		PollTimeout(testTimeout),
-		Concurrency(2),
-	)
+		append(defaultOpts, Concurrency(2))...)
 
 	km := newFakeKafkaMessage()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -704,6 +692,8 @@ func testMiddleware(name string, pre, post *[]string) MiddlewareFunc {
 }
 
 func newTestConsumer(t *testing.T, opts ...ConsumerOption) (*Consumer, *MockConsumerClient) {
+	t.Helper()
+
 	mockConsumer := &MockConsumerClient{}
 
 	opts = append(opts, mockConsumerFunc(mockConsumer))

--- a/xkafka/consumer_test.go
+++ b/xkafka/consumer_test.go
@@ -17,7 +17,7 @@ var (
 	testTopics  = Topics{"test-topic"}
 	testBrokers = Brokers{"localhost:9092"}
 	testTimeout = time.Second
-	defaultOpts = []Option{
+	defaultOpts = []ConsumerOption{
 		testTopics,
 		testBrokers,
 		PollTimeout(testTimeout),
@@ -255,15 +255,15 @@ func TestConsumerHandleMessageError(t *testing.T) {
 
 	testcases := []struct {
 		name    string
-		options []Option
+		options []ConsumerOption
 	}{
 		{
 			name:    "sequential",
-			options: []Option{},
+			options: []ConsumerOption{},
 		},
 		{
 			name: "async",
-			options: []Option{
+			options: []ConsumerOption{
 				Concurrency(2),
 			},
 		},
@@ -302,15 +302,15 @@ func TestConsumerErrorCallback(t *testing.T) {
 
 	testcases := []struct {
 		name    string
-		options []Option
+		options []ConsumerOption
 	}{
 		{
 			name:    "sequential",
-			options: []Option{},
+			options: []ConsumerOption{},
 		},
 		{
 			name: "async",
-			options: []Option{
+			options: []ConsumerOption{
 				Concurrency(2),
 			},
 		},
@@ -357,15 +357,15 @@ func TestConsumerReadMessageTimeout(t *testing.T) {
 
 	testcases := []struct {
 		name    string
-		options []Option
+		options []ConsumerOption
 	}{
 		{
 			name:    "sequential",
-			options: []Option{},
+			options: []ConsumerOption{},
 		},
 		{
 			name: "async",
-			options: []Option{
+			options: []ConsumerOption{
 				Concurrency(2),
 			},
 		},
@@ -418,15 +418,15 @@ func TestConsumerKafkaError(t *testing.T) {
 
 	testcases := []struct {
 		name    string
-		options []Option
+		options []ConsumerOption
 	}{
 		{
 			name:    "sequential",
-			options: []Option{},
+			options: []ConsumerOption{},
 		},
 		{
 			name: "async",
-			options: []Option{
+			options: []ConsumerOption{
 				Concurrency(2),
 			},
 		},
@@ -591,15 +591,15 @@ func TestConsumerStoreOffsetsError(t *testing.T) {
 
 	testcases := []struct {
 		name    string
-		options []Option
+		options []ConsumerOption
 	}{
 		{
 			name:    "sequential",
-			options: []Option{},
+			options: []ConsumerOption{},
 		},
 		{
 			name: "async",
-			options: []Option{
+			options: []ConsumerOption{
 				Concurrency(2),
 			},
 		},
@@ -643,17 +643,17 @@ func TestConsumerCommitError(t *testing.T) {
 
 	testcases := []struct {
 		name    string
-		options []Option
+		options []ConsumerOption
 	}{
 		{
 			name: "sequential",
-			options: []Option{
+			options: []ConsumerOption{
 				ManualCommit(true),
 			},
 		},
 		{
 			name: "async",
-			options: []Option{
+			options: []ConsumerOption{
 				ManualCommit(true),
 				Concurrency(2),
 			},
@@ -703,7 +703,7 @@ func testMiddleware(name string, pre, post *[]string) MiddlewareFunc {
 	}
 }
 
-func newTestConsumer(t *testing.T, opts ...Option) (*Consumer, *MockConsumerClient) {
+func newTestConsumer(t *testing.T, opts ...ConsumerOption) (*Consumer, *MockConsumerClient) {
 	mockConsumer := &MockConsumerClient{}
 
 	opts = append(opts, mockConsumerFunc(mockConsumer))

--- a/xkafka/error.go
+++ b/xkafka/error.go
@@ -5,6 +5,9 @@ import "errors"
 var (
 	// ErrRetryable is the error message for retryable errors.
 	ErrRetryable = errors.New("xkafka: retryable error")
+	// ErrRequiredOption is returned when a required option is
+	// not provided.
+	ErrRequiredOption = errors.New("xkafka: required option not provided")
 )
 
 // ErrorHandler is a callback function that is called when an error occurs.

--- a/xkafka/error.go
+++ b/xkafka/error.go
@@ -10,7 +10,9 @@ var (
 // ErrorHandler is a callback function that is called when an error occurs.
 type ErrorHandler func(err error) error
 
-func (h ErrorHandler) apply(o *options) { o.errorHandler = h }
+func (h ErrorHandler) setConsumerConfig(o *consumerConfig) { o.errorHandler = h }
+
+func (h ErrorHandler) setProducerConfig(o *producerConfig) { o.errorHandler = h }
 
 // NoopErrorHandler is an ErrorHandler that passes the error through.
 func NoopErrorHandler(err error) error { return err }

--- a/xkafka/options.go
+++ b/xkafka/options.go
@@ -2,32 +2,25 @@ package xkafka
 
 import (
 	"time"
-
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
-const (
-	atleastLeaderAck = 1
-	partitioner      = "consistent_random"
-)
-
-// Option is an interface for consumer options.
-type Option interface{ apply(*options) }
-
-// Brokers is an option to set the brokers.
+// Brokers sets the kafka brokers.
 type Brokers []string
 
-func (b Brokers) apply(o *options) { o.brokers = b }
+func (b Brokers) setConsumerConfig(o *consumerConfig) { o.brokers = b }
 
-// Topics is an option to set the topics.
-type Topics []string
+func (b Brokers) setProducerConfig(o *producerConfig) { o.brokers = b }
 
-func (t Topics) apply(o *options) { o.topics = t }
-
-// ConfigMap is an option to set kafka.ConfigMap.
+// ConfigMap allows setting kafka configuration.
 type ConfigMap map[string]interface{}
 
-func (cm ConfigMap) apply(o *options) {
+func (cm ConfigMap) setConsumerConfig(o *consumerConfig) {
+	for k, v := range cm {
+		_ = o.configMap.SetKey(k, v)
+	}
+}
+
+func (cm ConfigMap) setProducerConfig(o *producerConfig) {
 	for k, v := range cm {
 		_ = o.configMap.SetKey(k, v)
 	}
@@ -36,84 +29,10 @@ func (cm ConfigMap) apply(o *options) {
 // ShutdownTimeout defines the timeout for the consumer/producer to shutdown.
 type ShutdownTimeout time.Duration
 
-func (st ShutdownTimeout) apply(o *options) { o.shutdownTimeout = time.Duration(st) }
-
-// PollTimeout defines the timeout for the consumer read timeout.
-type PollTimeout time.Duration
-
-func (pt PollTimeout) apply(o *options) { o.pollTimeout = time.Duration(pt) }
-
-// MetadataTimeout defines the timeout for the consumer metadata request.
-type MetadataTimeout time.Duration
-
-func (mt MetadataTimeout) apply(o *options) { o.metadataTimeout = time.Duration(mt) }
-
-// Concurrency defines the concurrency of the consumer.
-type Concurrency int
-
-func (c Concurrency) apply(o *options) { o.concurrency = int(c) }
-
-// DeliveryCallback is a callback function triggered for every published message.
-// Works only for xkafka.Producer.
-type DeliveryCallback AckFunc
-
-func (d DeliveryCallback) apply(o *options) { o.deliveryCb = d }
-
-// ManualCommit disables the auto commit and calls the `Commit` after every
-// message is marked as `Success` or `Skip` by the handler.
-//
-// Works only for xkafka.Consumer.
-//
-// WARNING: Using this option will increase the message processing time,
-// because of the synchronous `Commit` for every message.
-type ManualCommit bool
-
-func (mc ManualCommit) apply(o *options) { o.manualCommit = bool(mc) }
-
-type options struct {
-	// common options
-	brokers         []string
-	configMap       kafka.ConfigMap
-	errorHandler    ErrorHandler
-	shutdownTimeout time.Duration
-
-	// consumer options
-	consumerFn      consumerFunc
-	topics          []string
-	metadataTimeout time.Duration
-	pollTimeout     time.Duration
-	concurrency     int
-	manualCommit    bool
-
-	// producer options
-	producerFn producerFunc
-	deliveryCb DeliveryCallback
+func (st ShutdownTimeout) setConsumerConfig(o *consumerConfig) {
+	o.shutdownTimeout = time.Duration(st)
 }
 
-func defaultConsumerOptions() options {
-	return options{
-		consumerFn:      defaultConsumerFunc,
-		topics:          []string{},
-		brokers:         []string{},
-		configMap:       kafka.ConfigMap{},
-		errorHandler:    NoopErrorHandler,
-		metadataTimeout: 10 * time.Second,
-		pollTimeout:     10 * time.Second,
-		shutdownTimeout: 1 * time.Second,
-		concurrency:     1,
-	}
-}
-
-func defaultProducerOptions() options {
-	return options{
-		producerFn: defaultProducerFunc,
-		brokers:    []string{},
-		configMap: kafka.ConfigMap{
-			"default.topic.config": kafka.ConfigMap{
-				"acks":        atleastLeaderAck,
-				"partitioner": partitioner,
-			},
-		},
-		errorHandler: NoopErrorHandler,
-	}
+func (st ShutdownTimeout) setProducerConfig(o *producerConfig) {
+	o.shutdownTimeout = time.Duration(st)
 }

--- a/xkafka/producer.go
+++ b/xkafka/producer.go
@@ -12,7 +12,7 @@ import (
 // It provides both synchronous and asynchronous publish methods
 // and a channel to stream delivery events.
 type Producer struct {
-	config              options
+	config              *producerConfig
 	kafka               producerClient
 	events              chan kafka.Event
 	middlewares         []middleware
@@ -21,13 +21,13 @@ type Producer struct {
 }
 
 // NewProducer creates a new Producer.
-func NewProducer(name string, opts ...Option) (*Producer, error) {
-	cfg := defaultProducerOptions()
-
-	for _, opt := range opts {
-		opt.apply(&cfg)
+func NewProducer(name string, opts ...ProducerOption) (*Producer, error) {
+	cfg, err := newProducerConfig(opts...)
+	if err != nil {
+		return nil, err
 	}
 
+	// override kafka configs
 	_ = cfg.configMap.SetKey("bootstrap.servers", strings.Join(cfg.brokers, ","))
 	_ = cfg.configMap.SetKey("client.id", name)
 

--- a/xkafka/producer_options.go
+++ b/xkafka/producer_options.go
@@ -1,0 +1,53 @@
+package xkafka
+
+import (
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+const (
+	atleastLeaderAck = 1
+	partitioner      = "consistent_random"
+)
+
+// ProducerOption is an interface for producer options.
+type ProducerOption interface{ setProducerConfig(*producerConfig) }
+
+type producerConfig struct {
+	brokers         []string
+	configMap       kafka.ConfigMap
+	errorHandler    ErrorHandler
+	shutdownTimeout time.Duration
+	producerFn      producerFunc
+	deliveryCb      DeliveryCallback
+}
+
+func newProducerConfig(opts ...ProducerOption) (*producerConfig, error) {
+	cfg := &producerConfig{
+		producerFn: defaultProducerFunc,
+		brokers:    []string{},
+		configMap: kafka.ConfigMap{
+			"default.topic.config": kafka.ConfigMap{
+				"acks":        atleastLeaderAck,
+				"partitioner": partitioner,
+			},
+		},
+		errorHandler:    NoopErrorHandler,
+		shutdownTimeout: 1 * time.Second,
+	}
+
+	for _, opt := range opts {
+		opt.setProducerConfig(cfg)
+	}
+
+	return cfg, nil
+}
+
+// DeliveryCallback is a callback function triggered for every published message.
+// Works only for xkafka.Producer.
+type DeliveryCallback AckFunc
+
+func (d DeliveryCallback) setProducerConfig(o *producerConfig) {
+	o.deliveryCb = d
+}

--- a/xkafka/producer_test.go
+++ b/xkafka/producer_test.go
@@ -421,7 +421,7 @@ func TestProducerIgnoreOpaqueMessage(t *testing.T) {
 	mockKafka.AssertExpectations(t)
 }
 
-func newTestProducer(t *testing.T, opts ...Option) (*Producer, *MockProducerClient) {
+func newTestProducer(t *testing.T, opts ...ProducerOption) (*Producer, *MockProducerClient) {
 	mockKafka := &MockProducerClient{}
 
 	mockKafka.On("Events").Return(make(chan kafka.Event, 1))

--- a/xkafka/producer_test.go
+++ b/xkafka/producer_test.go
@@ -2,7 +2,6 @@ package xkafka
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -14,6 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var defaultProducerOptions = []ProducerOption{
+	testBrokers,
+	errHandler,
+}
+
 func TestNewProducer(t *testing.T) {
 	cfg := ConfigMap{
 		"socket.keepalive.enable": true,
@@ -21,9 +25,7 @@ func TestNewProducer(t *testing.T) {
 
 	producer, err := NewProducer(
 		"test-producer",
-		testBrokers,
-		cfg,
-		ShutdownTimeout(testTimeout),
+		append(defaultProducerOptions, cfg, ShutdownTimeout(testTimeout))...,
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -44,21 +46,41 @@ func TestNewProducer(t *testing.T) {
 	assert.EqualValues(t, expectedConfig, producer.config.configMap)
 }
 
-func TestNewProducerError(t *testing.T) {
-	expectError := errors.New("error in producer")
-
-	fn := func(configMap *kafka.ConfigMap) (producerClient, error) {
-		return nil, expectError
+func TestNewProducerErrors(t *testing.T) {
+	testcases := []struct {
+		name    string
+		options []ProducerOption
+		expect  error
+	}{
+		{
+			name:    "missing brokers",
+			options: []ProducerOption{errHandler},
+			expect:  ErrRequiredOption,
+		},
+		{
+			name:    "missing error handler",
+			options: []ProducerOption{testBrokers},
+			expect:  ErrRequiredOption,
+		},
+		{
+			name: "producer error",
+			options: []ProducerOption{
+				testBrokers, errHandler,
+				producerFunc(func(configMap *kafka.ConfigMap) (producerClient, error) {
+					return nil, assert.AnError
+				}),
+			},
+			expect: assert.AnError,
+		},
 	}
 
-	producer, err := NewProducer(
-		"test-producer",
-		testBrokers,
-		ConfigMap{},
-		producerFunc(fn),
-	)
-	assert.EqualError(t, err, expectError.Error())
-	assert.Nil(t, producer)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewProducer("test-producer", tc.options...)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, tc.expect)
+		})
+	}
 }
 
 func TestProducerPublish(t *testing.T) {
@@ -428,7 +450,8 @@ func newTestProducer(t *testing.T, opts ...ProducerOption) (*Producer, *MockProd
 	mockKafka.On("Close").Return()
 	mockKafka.On("Flush", mock.Anything).Return(0)
 
-	opts = append(opts, testBrokers, mockProducerFunc(mockKafka), ShutdownTimeout(time.Second))
+	opts = append(defaultProducerOptions, opts...)
+	opts = append(opts, mockProducerFunc(mockKafka), ShutdownTimeout(time.Second))
 
 	producer, err := NewProducer(
 		"producer-id",


### PR DESCRIPTION
This PR separates consumer and producer configs and adds validation for mandatory options.

This PR also introduces a breaking change. `xkafka.ErrorHandler` is now mandatory while creating consumer or producer 