### PR TITLE
Ignores ErrNoOffset on manual commit

### DIFF
--- a/.changeset/calm-otter-commit.md
+++ b/.changeset/calm-otter-commit.md
@@ -1,0 +1,5 @@
+---
+"xkafka": patch
+---
+
+Treat `kafka.ErrNoOffset` ("Local: No offset stored") from a manual `Commit()` as a benign no-op instead of a fatal error, for both `Consumer` and `BatchConsumer`. With `Concurrency > 1` and `ManualCommit(true)`, the poll loop can service a rebalance (`Unassign` clears the stored offsets) on another goroutine between `StoreOffsets` and `Commit`, leaving the store empty; the partition's new owner resumes from the last committed offset, so there is no data loss and the consumer should not stop.

--- a/xkafka/batch_consumer.go
+++ b/xkafka/batch_consumer.go
@@ -287,7 +287,7 @@ func (c *BatchConsumer) storeBatch(batch *Batch) error {
 
 	if c.config.manualCommit {
 		_, err := c.kafka.Commit()
-		if err != nil {
+		if err != nil && !isErrNoOffset(err) {
 			return err
 		}
 	}

--- a/xkafka/batch_consumer_test.go
+++ b/xkafka/batch_consumer_test.go
@@ -664,6 +664,37 @@ func TestBatchConsumer_CommitError(t *testing.T) {
 	}
 }
 
+func TestBatchConsumer_StoreBatchNoOffsetIgnored(t *testing.T) {
+	t.Parallel()
+
+	opts := append(defaultOpts, ManualCommit(true))
+	consumer, mockKafka := newTestBatchConsumer(t, opts...)
+
+	topic := "topic1"
+	assignBatchPartitions(t, consumer, mockKafka, topic, 0)
+
+	batch := NewBatch()
+	batch.Messages = append(batch.Messages, &Message{
+		Topic:     topic,
+		Partition: 0,
+		Offset:    100,
+	})
+	batch.AckSuccess()
+
+	// A concurrent rebalance can clear the offset store between StoreOffsets
+	// and Commit, making Commit return ErrNoOffset. This is benign and must
+	// not stop the consumer.
+	noOffset := kafka.NewError(kafka.ErrNoOffset, "Local: No offset stored", false)
+
+	mockKafka.On("StoreOffsets", mock.Anything).Return(nil, nil)
+	mockKafka.On("Commit").Return(nil, noOffset)
+
+	err := consumer.storeBatch(batch)
+
+	assert.NoError(t, err)
+	mockKafka.AssertExpectations(t)
+}
+
 func TestBatchConsumer_RebalanceCallback(t *testing.T) {
 	t.Parallel()
 

--- a/xkafka/consumer.go
+++ b/xkafka/consumer.go
@@ -261,17 +261,7 @@ func (c *Consumer) storeMessage(msg *Message) error {
 
 	if c.config.manualCommit {
 		_, err := c.kafka.Commit()
-		if err != nil {
-			// ErrNoOffset ("Local: No offset stored") is benign: there is nothing
-			// to commit for the current assignment. With concurrency > 1 the poll
-			// loop can service a rebalance (Unassign clears the stored offsets) on
-			// another goroutine between StoreOffsets and Commit here, leaving the
-			// store empty. Treat it as a no-op instead of stopping the consumer.
-			var kerr kafka.Error
-			if errors.As(err, &kerr) && kerr.Code() == kafka.ErrNoOffset {
-				return nil
-			}
-
+		if err != nil && !isErrNoOffset(err) {
 			return err
 		}
 	}

--- a/xkafka/consumer.go
+++ b/xkafka/consumer.go
@@ -262,6 +262,16 @@ func (c *Consumer) storeMessage(msg *Message) error {
 	if c.config.manualCommit {
 		_, err := c.kafka.Commit()
 		if err != nil {
+			// ErrNoOffset ("Local: No offset stored") is benign: there is nothing
+			// to commit for the current assignment. With concurrency > 1 the poll
+			// loop can service a rebalance (Unassign clears the stored offsets) on
+			// another goroutine between StoreOffsets and Commit here, leaving the
+			// store empty. Treat it as a no-op instead of stopping the consumer.
+			var kerr kafka.Error
+			if errors.As(err, &kerr) && kerr.Code() == kafka.ErrNoOffset {
+				return nil
+			}
+
 			return err
 		}
 	}

--- a/xkafka/consumer_test.go
+++ b/xkafka/consumer_test.go
@@ -1047,6 +1047,34 @@ func TestConsumer_StoreMessage(t *testing.T) {
 		mockKafka.AssertExpectations(t)
 	})
 
+	t.Run("ManualCommitNoOffsetIgnored", func(t *testing.T) {
+		opts := append(defaultOpts, ManualCommit(true))
+		consumer, mockKafka := newTestConsumer(t, opts...)
+
+		topic := "topic1"
+		assignPartitions(t, consumer, mockKafka, topic, 0)
+
+		msg := &Message{
+			Topic:     topic,
+			Partition: 0,
+			Offset:    100,
+			Status:    Success,
+		}
+
+		// A concurrent rebalance can clear the offset store between StoreOffsets
+		// and Commit, making Commit return ErrNoOffset. This is benign and must
+		// not stop the consumer.
+		noOffset := kafka.NewError(kafka.ErrNoOffset, "Local: No offset stored", false)
+
+		mockKafka.On("StoreOffsets", mock.Anything).Return(nil, nil)
+		mockKafka.On("Commit").Return(nil, noOffset)
+
+		err := consumer.storeMessage(msg)
+
+		assert.NoError(t, err)
+		mockKafka.AssertExpectations(t)
+	})
+
 	t.Run("OffsetIncrementedByOne", func(t *testing.T) {
 		consumer, mockKafka := newTestConsumer(t, defaultOpts...)
 

--- a/xkafka/error.go
+++ b/xkafka/error.go
@@ -1,6 +1,10 @@
 package xkafka
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
 
 var (
 	// ErrRetryable is the error message for retryable errors.
@@ -9,6 +13,19 @@ var (
 	// not provided.
 	ErrRequiredOption = errors.New("xkafka: required option not provided")
 )
+
+// isErrNoOffset reports whether err is librdkafka's ErrNoOffset
+// ("Local: No offset stored"), which a manual Commit returns when there is
+// nothing to commit for the current assignment. This is benign: with
+// concurrency > 1 the poll loop can service a rebalance (Unassign clears the
+// stored offsets) on another goroutine between StoreOffsets and Commit,
+// leaving the store empty. The partition's new owner resumes from the last
+// committed offset, so it is safe to treat as a no-op.
+func isErrNoOffset(err error) bool {
+	var kerr kafka.Error
+
+	return errors.As(err, &kerr) && kerr.Code() == kafka.ErrNoOffset
+}
 
 // ErrorHandler is a callback function that is called when an error occurs.
 type ErrorHandler func(err error) error


### PR DESCRIPTION
## Summary

Fix `Local: No offset stored` (`kafka.ErrNoOffset`) errors that crash the consumer when `Concurrency > 1` and `ManualCommit(true)` are used together.

The error is benign — it means there is nothing to commit for the current assignment — but `storeMessage` was propagating it as a fatal error, which stopped the consumer (and, for callers that kill the pod on consumer error, took the pod down with it).

## Background

The consumer has two execution paths, selected by concurrency:

| Path | When | Poll & commit run on… |
|------|------|-----------------------|
| `runSequential` | `Concurrency == 1` | the **same** goroutine (strictly interleaved) |
| `runAsync` | `Concurrency > 1` | **separate** goroutines (poll loop vs. `conc/stream` callbacker) |

In `runSequential`, `ReadMessage` → `Handle` → `StoreOffsets` → `Commit` never overlap, so the offset store is always populated when `Commit()` runs.

In `runAsync`, the main goroutine keeps calling `ReadMessage` (which is where librdkafka services rebalance callbacks) while a separate callbacker goroutine runs `storeMessage` (`StoreOffsets` + `Commit`). These now race.

## Root cause

A rebalance is delivered **inside `ReadMessage`** on the poll goroutine. Its callback calls `Unassign()`, which clears librdkafka's stored offsets. If that lands between `StoreOffsets` and `Commit` in the callbacker goroutine, the store is empty at commit time and `Commit()` returns `ErrNoOffset`.

### Sequence of the race

```mermaid
sequenceDiagram
    participant Poll as Poll goroutine<br/>(runAsync loop)
    participant RB as Rebalance callback
    participant CB as Callbacker goroutine<br/>(storeMessage)
    participant RD as librdkafka<br/>(offset store)

    Note over CB,RD: message handled OK, partition still active
    CB->>RD: StoreOffsets(offset+1)
    RD-->>CB: ok (offset stored)

    Poll->>RB: ReadMessage() delivers RevokedPartitions
    RB->>RD: Unassign()
    RD-->>RB: ok (stored offsets CLEARED)

    CB->>RD: Commit()
    RD-->>CB: ErrNoOffset ("Local: No offset stored")

    Note over CB: before: return err → cancel() → consumer stops ❌
    Note over CB: after:  ErrNoOffset → return nil (no-op) ✅
```

Because the two paths only overlap when `Concurrency > 1`, the issue never reproduces at concurrency 1.

## The fix

Treat `kafka.ErrNoOffset` from the manual `Commit()` as a no-op instead of a fatal error. The offset is either already committed or the partition has moved to another consumer during a rebalance — in both cases the new owner correctly resumes from the last committed offset, so there is no data loss.

```mermaid
flowchart TD
    A["storeMessage: Commit()"] --> B{"err != nil?"}
    B -- no --> E["return nil"]
    B -- yes --> C{"err is ErrNoOffset?"}
    C -- "yes (benign)" --> E
    C -- "no (real error)" --> D["return err → stop consumer"]
```

## Testing

- Added `TestConsumer_StoreMessage/ManualCommitNoOffsetIgnored`, stubbing `Commit()` to return `ErrNoOffset` and asserting no error.
- Verified the new test **fails without the fix** and **passes with it**; full `TestConsumer*` suite green.

## Impact / risk

- Only the `ErrNoOffset` case changes; all other commit errors still stop the consumer.
- No API/config changes, no data-loss risk.