### PR TITLE
ci: authenticate go-git tag push in publish workflow

### DIFF
--- a/.changeset/fancy-parrot-roll.md
+++ b/.changeset/fancy-parrot-roll.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the publish workflow so `changeset publish` can authenticate its go-git tag push. CI-only change; no module release.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,6 +28,16 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # `changeset publish` pushes tags via go-git, which does not read the
+      # http.extraheader credentials actions/checkout configures. Embed the
+      # token in the origin URL so go-git can authenticate the push. Without
+      # this the push fails with "authentication required: No anonymous write
+      # access" and no tags are published.
+      - name: Authenticate git remote for go-git
+        run: git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
         run: changeset publish


### PR DESCRIPTION
## Problem

The `Publish` workflow failed on the last release ([run](https://github.com/gojekfarm/xtools/actions/runs/28578251933)):

```
INF Pushing tags to origin
Failed to push tags: pushing tags: authentication required: No anonymous write access.
```

All tags were created but **none were pushed** — `xkafka/v0.11.1` (and the cascade dependency tags) had to be pushed manually to complete the release.

## Root cause

`changeset publish` pushes via **go-git** — [`PushTags`](https://github.com/gojekfarm/xtools/blob/main/cmd/changeset/git/git.go#L106) calls `repo.Push(&git.PushOptions{...})` with **no `Auth`**. go-git does **not** read the `http.<url>.extraheader` credential that `actions/checkout` injects for the `GITHUB_TOKEN`, so the push goes out anonymously and GitHub rejects it.

## Fix (workflow-only)

- `permissions: contents: write` on the job so the token has push scope.
- Rewrite the `origin` remote URL to embed the token (`https://x-access-token:${GITHUB_TOKEN}@github.com/...`). go-git **does** read URL userinfo, so the push now authenticates.

No change to the `changeset` tool or its released version.

## Follow-up (optional, deeper fix)

The tool itself should authenticate its own push so it works in any CI without URL hacks: add `Auth: &http.BasicAuth{Username: "x-access-token", Password: os.Getenv("GITHUB_TOKEN")}` to `PushTags` in `cmd/changeset/git/git.go`. Left out here to keep this change to the workflow and avoid re-releasing `cmd/changeset`.

## Notes

- CI-only change → empty changeset included (per the repo's documented convention for CI/docs PRs); no module is released.